### PR TITLE
Fix status update error for CRs

### DIFF
--- a/controllers/volumesnapshotbackup_controller.go
+++ b/controllers/volumesnapshotbackup_controller.go
@@ -159,6 +159,15 @@ func (r *VolumeSnapshotBackupReconciler) Reconcile(ctx context.Context, req ctrl
 			})
 	}
 
+	// get VSB again before updating status here
+	// since it has been updated in reconcile batch, resourceVersion has changed
+	// prevents "the object has been modified; please apply your changes to the latest version and try again" err
+	vsb = datamoverv1alpha1.VolumeSnapshotBackup{}
+	if err := r.Client.Get(ctx, req.NamespacedName, &vsb); err != nil {
+		r.Log.Error(err, "unable to fetch VolumeSnapshotBackup CR")
+		return result, err
+	}
+
 	statusErr := r.Client.Status().Update(ctx, &vsb)
 	if err == nil { // Don't mask previous error
 		err = statusErr

--- a/controllers/volumesnapshotrestore_controller.go
+++ b/controllers/volumesnapshotrestore_controller.go
@@ -127,6 +127,15 @@ func (r *VolumeSnapshotRestoreReconciler) Reconcile(ctx context.Context, req ctr
 			})
 	}
 
+	// get VSR again before updating status here
+	// since it has been updated in reconcile batch, resourceVersion has changed
+	// prevents "the object has been modified; please apply your changes to the latest version and try again" err
+	vsr = datamoverv1alpha1.VolumeSnapshotRestore{}
+	if err := r.Client.Get(ctx, req.NamespacedName, &vsr); err != nil {
+		r.Log.Error(err, "unable to fetch VolumeSnapshotRestore CR")
+		return result, err
+	}
+
 	statusErr := r.Client.Status().Update(ctx, &vsr)
 	if err == nil { // Don't mask previous error
 		err = statusErr


### PR DESCRIPTION
#92 
Fixes error `ERROR   controller.volumesnapshotbackup Reconciler error        {"reconciler group": "datamover.oadp.openshift.io", "reconciler kind": "VolumeSnapshotBackup", "name": "vsb-velero-rocketchat-data-claim-s94d6", "namespace": "rocket-chat", "error": "Operation cannot be fulfilled on volumesnapshotbackups.datamover.oadp.openshift.io \"vsb-velero-rocketchat-data-claim-xxxx\": the object has been modified; please apply your changes to the latest version and try again"}`