### PR TITLE
Update mutation fn to stop incorrect updates

### DIFF
--- a/controllers/pvc.go
+++ b/controllers/pvc.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
 	"github.com/go-logr/logr"
 	volsnapmoverv1alpha1 "github.com/konveyor/volume-snapshot-mover/api/v1alpha1"
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
@@ -81,18 +80,20 @@ func (r *VolumeSnapshotBackupReconciler) buildPVCClone(pvcClone *corev1.Persiste
 		return err
 	}
 
-	apiGroup := "snapshot.storage.k8s.io"
-	pvcClone.Spec.DataSource = &corev1.TypedLocalObjectReference{
-		Name:     vsClone.Name,
-		Kind:     vsClone.Kind,
-		APIGroup: &apiGroup,
+	if pvcClone.CreationTimestamp.IsZero() {
+		apiGroup := "snapshot.storage.k8s.io"
+		pvcClone.Spec.DataSource = &corev1.TypedLocalObjectReference{
+			Name:     vsClone.Name,
+			Kind:     vsClone.Kind,
+			APIGroup: &apiGroup,
+		}
+
+		pvcClone.Spec.AccessModes = sourcePVC.Spec.AccessModes
+
+		pvcClone.Spec.Resources = sourcePVC.Spec.Resources
+
+		pvcClone.Spec.StorageClassName = sourcePVC.Spec.StorageClassName
 	}
-
-	pvcClone.Spec.AccessModes = sourcePVC.Spec.AccessModes
-
-	pvcClone.Spec.Resources = sourcePVC.Spec.Resources
-
-	pvcClone.Spec.StorageClassName = sourcePVC.Spec.StorageClassName
 
 	return nil
 }

--- a/controllers/replicationdestination.go
+++ b/controllers/replicationdestination.go
@@ -82,7 +82,10 @@ func (r *VolumeSnapshotRestoreReconciler) buildReplicationDestination(replicatio
 			},
 		},
 	}
-	replicationDestination.Spec = replicationDestinationSpec
+	if replicationDestination.CreationTimestamp.IsZero() {
+		replicationDestination.Spec = replicationDestinationSpec
+	}
+
 	return nil
 }
 

--- a/controllers/replicationsource.go
+++ b/controllers/replicationsource.go
@@ -84,7 +84,10 @@ func (r *VolumeSnapshotBackupReconciler) buildReplicationSource(replicationSourc
 			},
 		},
 	}
-	replicationSource.Spec = replicationSourceSpec
+	if replicationSource.CreationTimestamp.IsZero() {
+		replicationSource.Spec = replicationSourceSpec
+	}
+
 	return nil
 }
 

--- a/controllers/volumesnapshot.go
+++ b/controllers/volumesnapshot.go
@@ -142,7 +142,10 @@ func (r *VolumeSnapshotBackupReconciler) buildVolumeSnapshotContentClone(vscClon
 		},
 	}
 
-	vscClone.Spec = newSpec
+	if vscClone.CreationTimestamp.IsZero() {
+		vscClone.Spec = newSpec
+	}
+
 	return nil
 }
 
@@ -154,7 +157,10 @@ func (r *VolumeSnapshotBackupReconciler) buildVolumeSnapshotClone(vsClone *snapv
 		},
 	}
 
-	vsClone.Spec = vsSpec
+	if vsClone.CreationTimestamp.IsZero() {
+		vsClone.Spec = vsSpec
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This PR adds a check based on Creation timestamp to stop incorrect/redundant updates to the resources.