### PR TITLE
Pass goarch for building arch-specific image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM golang:1.19 as builder
+
+ARG GOARCH=${ARCH}
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -15,7 +17,7 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+#Set architecture
+ARCH=$(shell arch)
+
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
@@ -71,7 +74,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	docker build --build-arg ARCH=${ARCH} -t ${IMG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.


### PR DESCRIPTION
The Dockerfile currently uses `golang:1.17` as base image, which doesn't support P/Z architectures. The `go build` command also has `amd64` hard-coded as the GOARCH.

The `volume-snapshot-mover` pod which uses this image fails with following error:

```
[root@rdr-sg-e2e-3550-tok04-bastion-0 oadp-e2e-qe]# oc logs volume-snapshot-mover-64cdcf4b97-f5zkx
exec /manager: exec format error
```

The changes proposed in this PR -

1. Updated golang image to use tag 1.19 which supports multiple architectures
2. Passing the ARCH to the Dockerfile to build the image for the required architecture